### PR TITLE
Deprecate Firestore Contacts Collection

### DIFF
--- a/app/src/main/java/com/minim/messenger/activities/ConversationActivity.kt
+++ b/app/src/main/java/com/minim/messenger/activities/ConversationActivity.kt
@@ -23,17 +23,17 @@ class ConversationActivity : AppCompatActivity() {
         setContentView(R.layout.activity_conversation)
 
         conversation = intent.getParcelableExtra<Conversation>("conversation")!!
-        adapter = ConversationAdapter(conversation.messages!!)
+        adapter = ConversationAdapter(conversation.messages)
 
-        contact_username_text_view.text = conversation.participant_2!!.username
+        contact_username_text_view.text = conversation.participants[1].username
         initRecyclerView()
         initMessagesListeners(conversation.id)
 
         send_button.setOnClickListener {
 
             val message = Message(
-                conversation.participant_1!!.username,
-                conversation.participant_2!!.username,
+                conversation.participants[0].username,
+                conversation.participants[1].username,
                 Message.Type.TO,
                 message_edit_text.text.toString(),
                 false,

--- a/app/src/main/java/com/minim/messenger/models/Message.kt
+++ b/app/src/main/java/com/minim/messenger/models/Message.kt
@@ -20,6 +20,17 @@ data class Message(
         FROM
     }
 
+    constructor(hashMap: HashMap<*, *>) : this(
+        hashMap["sender"].toString(),
+        hashMap["receiver"].toString(),
+        Type.valueOf(hashMap["type"].toString()),
+        hashMap["content"].toString(),
+        hashMap["read"] as Boolean,
+        hashMap["duration"] as Long,
+        hashMap["sent"] as Timestamp,
+        hashMap["seen"] as Timestamp
+    )
+
     constructor(parcel: Parcel) : this(
         parcel.readString(),
         parcel.readString(),


### PR DESCRIPTION
 * Replace participant_1 and participant_2 fields in the Conversation Model with participants array of Users.
 * Use the conversations collection to fetch the current user's contacts by using array-contains query to fetch all the conversations that the user participated in, then get the other participant from the users collection.
 * Create overloaded constructor for the Message model to help constructing Message from a map while fetching messages.
 * Add processMessages method to alternate the Message's Type upon the currently signed in user.